### PR TITLE
 re-initialize on each handler call to prevent losing container element and crashing [ui-select 0.19.4]

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,23 +70,35 @@ angular
             link: function(scope, elem, attrs) {
                 var container = elem,
                     scrollDistance = angular.isDefined(attrs.scrollDistance) ? parseInt(attrs.scrollDistance) : 0.3,
-                    removeThrottle;
+                    removeThrottle,
+                    rows,
+                    lastChoice;
 
                 function tryToSetupInfinityScroll() {
-                    var rows = elem.querySelectorAll('.ui-select-choices-row');
 
-                    if (rows.length === 0) {
-                        return false;
+                    var initialize = function() {
+                      rows = elem.querySelectorAll('.ui-select-choices-row');
+
+                      if (rows.length === 0) {
+                          return false;
+                      }
+
+                      lastChoice = angular.element(rows[rows.length - 1]);
+
+                      container = angular.element(elem.querySelectorAll('.ui-select-choices-content'));
+                      return true;
                     }
 
-                    var lastChoice = angular.element(rows[rows.length - 1]);
-
-                    container = angular.element(elem.querySelectorAll('.ui-select-choices-content'));
+                    if (!initialize()) {
+                      return false;
+                    }
 
                     var handler = function() {
                         var containerBottom = height(container),
                             containerTopOffset = 0,
                             elementBottom;
+
+                        initialize(); // re-initialize to prevent losing container element
 
                         if (offsetTop(container) !== void 0) {
                             containerTopOffset = offsetTop(container);


### PR DESCRIPTION
Prevent "Uncaught TypeError: Cannot read property 'getBoundingClientRect' of undefined" when scrolling on dropdown while new search is executed and `container` element doesn't exist for a couple milliseconds (using with newest `ui-select 0.19.4`).
